### PR TITLE
Avoid buffer overflow in DFU callback function

### DIFF
--- a/config/transport_ble.c
+++ b/config/transport_ble.c
@@ -285,7 +285,8 @@ void DFUCallBack(uint32 event, void* eventParam)
     (void)eventParam;
 
     static uint16_t cyBle_btsDataPacketSize = 0u;
-    static uint8_t  cyBle_btsDataBuffer[CY_FLASH_SIZEOF_ROW + CYBLE_BTS_COMMAND_CONTROL_BYTES_NUM];
+    // Program Data Packet: data (row_size) + address (4 bytes) + crc-32c (4 bytes) + cmd_ctrl_bytes
+    static uint8_t  cyBle_btsDataBuffer[CY_FLASH_SIZEOF_ROW + 8 + CYBLE_BTS_COMMAND_CONTROL_BYTES_NUM];
     
     switch ((cy_en_ble_evt_t)event)
     {


### PR DESCRIPTION
Enlarge the btsDataBuffer in the DFU callback function to avoid buffer overflow when a Program Data command is used without a preceding Send Data command.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/cypresssemiconductorco/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.